### PR TITLE
Slather

### DIFF
--- a/.slather.yml
+++ b/.slather.yml
@@ -2,4 +2,7 @@ ci_service: travis_ci
 coverage_service: coveralls
 xcodeproj: Development/NMXCore.xcodeproj
 source_directory: NMXCore
-scheme: NMXCoreTests
+scheme: NMXCoreStatic
+ignore:
+- "Development/NMXCoreTests/*"
+- "Development/NMXCoreTestsStatic/*"

--- a/.slather.yml
+++ b/.slather.yml
@@ -2,7 +2,7 @@ ci_service: travis_ci
 coverage_service: coveralls
 xcodeproj: Development/NMXCore.xcodeproj
 source_directory: NMXCore
-scheme: NMXCoreStatic
+scheme: NMXCoreTestsStatic
 ignore:
 - "Development/NMXCoreTests/*"
 - "Development/NMXCoreTestsStatic/*"

--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,1 @@
-xcodebuild clean build -sdk iphonesimulator -project Development/NMXCore.xcodeproj -scheme NMXCoreTests CODE_SIGNING_REQUIRED=NO -destination 'platform=iOS Simulator,name=iPhone 8,OS=11.1' test GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES
+xcodebuild clean build -sdk iphonesimulator -project Development/NMXCore.xcodeproj -scheme NMXCoreTestsStatic CODE_SIGNING_REQUIRED=NO -destination 'platform=iOS Simulator,name=iPhone 8,OS=11.1' test GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES


### PR DESCRIPTION
#### What does this Pull Request do?
Previously, we tested the "coverage of the tests" - that obviously made no sense. 
Now we get the test coverage of our library.
Direct Link: https://coveralls.io/builds/14209370

#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant tickets/issues?
#### Screenshots (if appropriate)

#### Overall Developemnt requirements:
[ ] If you added new Header files, did you update `Header-ios-objc-foundation-nmxcore.h` or related header files, so the code documentation is able to retrieve your new files?
[ ] Did you write pretty printable code comments for added classes, properties or functions?
[ ] If you added properties, did you Nullability annotations? --> `_Nullable`, `_Nonnull`
[ ] If you added functions, did you Nullability annotations? --> `nullable`, `nonnull`, `null_resettable`, `null_unspecified`
[ ] Did you generate a new documentation file via `jazzy`-command?
[ ] Did you perform `pod lib lint NMXCore.podspec` and `pod lib lint NMXCoreDylib.podspec`
[ ] Did you test your code with Unit tests?
[x] Did the test coverage increase / did maintain the same level? --> If not, why?
Well, it looks like it decreased to 99.80 percent - but it actually did NOT decrease. 100% was wrong and related to the tests itself.

#### Release Management
[ ] Did you update the README.md with the latest version you are using
[ ] Did you perform `pod spec lint NMXCore.podspec` and `pod spec lint NMXCoreDylib.podspec`
[ ] Make the reviewer aware to `pod trunk push NMXCore.podspec --verbose` and `pod trunk push NMXCoreDylib.podspec --verbose` after the review. Or do it yourself.

#### Further Questions
- Is there a blog post?
- Does the knowledge base need an update?
- Does this add new dependencies which need to be added to the podspec file?
